### PR TITLE
Adding NPM dependencies for AirPlay Server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,106 @@
 {
   "name": "multipadmonitor",
   "version": "1.0.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "airplay-mdns-server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/airplay-mdns-server/-/airplay-mdns-server-2.0.0.tgz",
+      "integrity": "sha1-9W+1E0bNn5mDr2zWCOdrI5a/Rlg=",
+      "requires": {
+        "debug": "^2.2.0",
+        "getmac": "^1.0.7",
+        "mdns": "^2.2.9"
+      }
+    },
+    "airplay-server": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/airplay-server/-/airplay-server-1.1.0.tgz",
+      "integrity": "sha1-vxFhpemRC00iKxmKBS/4mYELGNk=",
+      "requires": {
+        "airplay-mdns-server": "^2.0.0",
+        "debug": "^2.2.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "eachr": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
+      "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
+      "requires": {
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
+      }
+    },
+    "editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+    },
+    "extract-opts": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz",
+      "integrity": "sha1-WrvtyYwNUgLjJ4cn+Rktfghsa+E=",
+      "requires": {
+        "eachr": "^3.2.0",
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
+      }
+    },
+    "getmac": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/getmac/-/getmac-1.4.3.tgz",
+      "integrity": "sha512-bOZafIX+19cCS5KUjHtlJPZW+4joMa5tISIk5CugjmlZE0zZtjwB59wm56JPXVy5ELivw7g4Z9TEI0EDa2CSwQ==",
+      "requires": {
+        "editions": "^1.3.4",
+        "extract-opts": "^3.2.0"
+      }
+    },
+    "mdns": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mdns/-/mdns-2.4.0.tgz",
+      "integrity": "sha512-t58BWOyagGpATg8LlALpnqjfT7VHBq6/HCLfU/SK0Ox+enx3Cut7voWB9DPwjrdoccql6Z6ZY1rwuBX93t0Vpw==",
+      "requires": {
+        "bindings": "~1.2.1",
+        "nan": "^2.10.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
+    "typechecker": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.5.0.tgz",
+      "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
+      "requires": {
+        "editions": "^1.3.4"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,7 @@
     "url": "https://github.com/mattddonovan/MultiPadMonitor/issues"
   },
   "homepage": "https://github.com/mattddonovan/MultiPadMonitor#readme",
-  "dependencies": {}
+  "dependencies": {
+    "airplay-server": "^1.1.0"
+  }
 }


### PR DESCRIPTION
This adds the required NPM modules to create an instance of an AirPlay Server compatible module. It includes and mDNSresponder service that properly advertises itself to Bonjour and Zeroconf devices